### PR TITLE
Fiksar release-mekanismen

### DIFF
--- a/.github/workflows/release-common-test.yaml
+++ b/.github/workflows/release-common-test.yaml
@@ -19,7 +19,7 @@ jobs:
 
       # Build
       - name: Test and build
-        run: ./gradlew :common-test:test :common-test:build
+        run: ./gradlew :common-test:build
 
   release:
     name: Create Release
@@ -32,20 +32,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
       - name: Set release tag
         run: |
           export TAG_NAME="$(TZ="Europe/Oslo" date +%Y.%m.%d-%H.%M).$(echo $GITHUB_SHA | cut -c 1-12)"
           echo "RELEASE_TAG=$TAG_NAME" >> $GITHUB_ENV
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
+        uses: elgohr/Github-Release-Action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: common-test.${{ env.RELEASE_TAG }}
-          release_name: common-test.${{ env.RELEASE_TAG }}
-          draft: false
-          prerelease: false
+          title: common-test.${{ env.RELEASE_TAG }}
       - name: Upload artifact
         run: ./gradlew :common-test:publish -Pversion="${{ env.RELEASE_TAG }}"
         env:

--- a/.github/workflows/release-common.yaml
+++ b/.github/workflows/release-common.yaml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v3
       - name: Set release tag
         run: |
           export TAG_NAME="$(TZ="Europe/Oslo" date +%Y.%m.%d-%H.%M).$(echo $GITHUB_SHA | cut -c 1-12)"

--- a/.github/workflows/release-common.yaml
+++ b/.github/workflows/release-common.yaml
@@ -28,7 +28,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release-common.yaml
+++ b/.github/workflows/release-common.yaml
@@ -19,7 +19,7 @@ jobs:
 
       # Build
       - name: Test and build
-        run: ./gradlew :common:test :common:build
+        run: ./gradlew :common:build
 
   release:
     name: Create Release

--- a/.github/workflows/release-common.yaml
+++ b/.github/workflows/release-common.yaml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release-common.yaml
+++ b/.github/workflows/release-common.yaml
@@ -33,6 +33,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Java
         uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
       - name: Set release tag
         run: |
           export TAG_NAME="$(TZ="Europe/Oslo" date +%Y.%m.%d-%H.%M).$(echo $GITHUB_SHA | cut -c 1-12)"

--- a/.github/workflows/release-common.yaml
+++ b/.github/workflows/release-common.yaml
@@ -37,14 +37,11 @@ jobs:
           echo "RELEASE_TAG=$TAG_NAME" >> $GITHUB_ENV
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
+        uses: elgohr/Github-Release-Action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: common.${{ env.RELEASE_TAG }}
-          release_name: common.${{ env.RELEASE_TAG }}
-          draft: false
-          prerelease: false
+          title: common.${{ env.RELEASE_TAG }}
       - name: Upload artifact
         run: ./gradlew :common:publish -Pversion="${{ env.RELEASE_TAG }}"
         env:

--- a/.github/workflows/release-ktor-client-auth.yaml
+++ b/.github/workflows/release-ktor-client-auth.yaml
@@ -19,7 +19,7 @@ jobs:
 
       # Build
       - name: Test and build
-        run: ./gradlew :ktor-client-auth:test :ktor-client-auth:build
+        run: ./gradlew :ktor-client-auth:build
 
   release:
     name: Create Release
@@ -32,20 +32,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
       - name: Set release tag
         run: |
           export TAG_NAME="$(TZ="Europe/Oslo" date +%Y.%m.%d-%H.%M).$(echo $GITHUB_SHA | cut -c 1-12)"
           echo "RELEASE_TAG=$TAG_NAME" >> $GITHUB_ENV
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
+        uses: elgohr/Github-Release-Action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ktor-client-auth.${{ env.RELEASE_TAG }}
-          release_name: ktor-client-auth.${{ env.RELEASE_TAG }}
-          draft: false
-          prerelease: false
+          title: ktor-client-auth.${{ env.RELEASE_TAG }}
       - name: Upload artifact
         run: ./gradlew :ktor-client-auth:publish -Pversion="${{ env.RELEASE_TAG }}"
         env:

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,8 +31,6 @@ allprojects {
     group = "no.nav.etterlatte"
     // version = blir håndtert av .github/workflows/release-*.yaml
 
-    apply(plugin = "org.jetbrains.kotlin.jvm")
-
     repositories {
         mavenCentral()
     }
@@ -44,6 +42,10 @@ allprojects {
 
         withType<KotlinCompile> {
             kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
+        }
+        java {
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "pensjon-etterlatte-libs"
+rootProject.name = "no.nav.etterlatte"
 
 plugins {
     kotlin("jvm") version "1.8.22" apply false


### PR DESCRIPTION
Cluet var å få inn setup-java, for at gradle publish skulle fungere ordentleg, og også å bytte release-action - den vi brukte før takla ikkje Java > 11, og github-repoet er arkivert