### PR TITLE
Fikse deserialisering av gjenlevende på OMS

### DIFF
--- a/common-test/src/main/kotlin/no/nav/etterlatte/libs/common/test/SoeknadFixtures.kt
+++ b/common-test/src/main/kotlin/no/nav/etterlatte/libs/common/test/SoeknadFixtures.kt
@@ -36,7 +36,6 @@ import no.nav.etterlatte.libs.common.innsendtsoeknad.YtelserNav
 import no.nav.etterlatte.libs.common.innsendtsoeknad.barnepensjon.Barnepensjon
 import no.nav.etterlatte.libs.common.innsendtsoeknad.barnepensjon.GjenlevendeForelder
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.Avdoed
-import no.nav.etterlatte.libs.common.innsendtsoeknad.common.AvdoedOMS
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.Barn
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.BetingetOpplysning
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.DatoSvar
@@ -401,7 +400,7 @@ object InnsendtSoeknadFixtures {
                     )
                 )
             ),
-            avdoed = AvdoedOMS(
+            avdoed = Avdoed(
                 fornavn = Opplysning(svar = "Bernt", spoersmaal = null),
                 etternavn = Opplysning(svar = "Jakobsen", spoersmaal = null),
                 foedselsnummer = Opplysning(
@@ -436,6 +435,7 @@ object InnsendtSoeknadFixtures {
                     spoersmaal = null
                 ),
                 naeringsInntekt = null,
+                militaertjeneste = null
             ),
             barn = listOf()
 

--- a/common/src/main/kotlin/no/nav/etterlatte/libs/common/innsendtsoeknad/common/Personer.kt
+++ b/common/src/main/kotlin/no/nav/etterlatte/libs/common/innsendtsoeknad/common/Personer.kt
@@ -31,6 +31,7 @@ import no.nav.etterlatte.libs.common.person.Foedselsnummer
 )
 @JsonSubTypes(
     JsonSubTypes.Type(value = Gjenlevende::class, name = "GJENLEVENDE"),
+    JsonSubTypes.Type(value = GjenlevendeOMS::class, name = "GJENLEVENDE_OMS"),
     JsonSubTypes.Type(value = GjenlevendeForelder::class, name = "GJENLEVENDE_FORELDER"),
     JsonSubTypes.Type(value = Avdoed::class, name = "AVDOED"),
     JsonSubTypes.Type(value = Samboer::class, name = "SAMBOER"),
@@ -49,6 +50,7 @@ interface Person {
 enum class PersonType {
     INNSENDER,
     GJENLEVENDE,
+    GJENLEVENDE_OMS,
     GJENLEVENDE_FORELDER,
     AVDOED,
     SAMBOER,
@@ -109,7 +111,7 @@ data class GjenlevendeOMS(
     val forholdTilAvdoede: ForholdTilAvdoedeOMS,
     val omsorgForBarn: Opplysning<EnumSvar<JaNeiVetIkke>>
 ) : Person {
-    override val type = PersonType.GJENLEVENDE
+    override val type = PersonType.GJENLEVENDE_OMS
 }
 
 data class Forelder(
@@ -136,22 +138,6 @@ data class Barn(
     override val type = PersonType.BARN
 }
 
-data class BarnOMS(
-    override val fornavn: Opplysning<String>,
-    override val etternavn: Opplysning<String>,
-    override val foedselsnummer: Opplysning<Foedselsnummer>,
-
-    val statsborgerskap: Opplysning<String>,
-    val utenlandsAdresse: BetingetOpplysning<EnumSvar<JaNeiVetIkke>, Utenlandsadresse?>?,
-    val bosattNorge: BetingetOpplysning<EnumSvar<JaNeiVetIkke>, OppholdUtlandInformasjon?>,
-    val foreldre: List<Forelder>,
-    val ukjentForelder: Opplysning<String>?,
-    val verge: BetingetOpplysning<EnumSvar<JaNeiVetIkke>, Verge>?,
-    val dagligOmsorg: Opplysning<EnumSvar<OmsorgspersonType>>?
-) : Person {
-    override val type = PersonType.BARN
-}
-
 data class Avdoed(
     override val fornavn: Opplysning<String>,
     override val etternavn: Opplysning<String>,
@@ -165,21 +151,6 @@ data class Avdoed(
     // Næringsinntekt og militærtjeneste er kun relevant dersom begge foreldrene er døde.
     val naeringsInntekt: BetingetOpplysning<EnumSvar<JaNeiVetIkke>, Naeringsinntekt?>?,
     val militaertjeneste: BetingetOpplysning<EnumSvar<JaNeiVetIkke>, Opplysning<AarstallForMilitaerTjeneste>?>?
-) : Person {
-    override val type = PersonType.AVDOED
-}
-
-data class AvdoedOMS(
-    override val fornavn: Opplysning<String>,
-    override val etternavn: Opplysning<String>,
-    override val foedselsnummer: Opplysning<Foedselsnummer>,
-
-    val datoForDoedsfallet: Opplysning<DatoSvar>,
-    val statsborgerskap: Opplysning<FritekstSvar>,
-    val utenlandsopphold: BetingetOpplysning<EnumSvar<JaNeiVetIkke>, List<Utenlandsopphold>>,
-    val doedsaarsakSkyldesYrkesskadeEllerYrkessykdom: Opplysning<EnumSvar<JaNeiVetIkke>>,
-
-    val naeringsInntekt: BetingetOpplysning<EnumSvar<JaNeiVetIkke>, Naeringsinntekt?>?,
 ) : Person {
     override val type = PersonType.AVDOED
 }

--- a/common/src/main/kotlin/no/nav/etterlatte/libs/common/innsendtsoeknad/omstillingsstoenad/Omstillingsstoenad.kt
+++ b/common/src/main/kotlin/no/nav/etterlatte/libs/common/innsendtsoeknad/omstillingsstoenad/Omstillingsstoenad.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import no.nav.etterlatte.libs.common.innsendtsoeknad.BankkontoType
 import no.nav.etterlatte.libs.common.innsendtsoeknad.Spraak
 import no.nav.etterlatte.libs.common.innsendtsoeknad.UtbetalingsInformasjon
-import no.nav.etterlatte.libs.common.innsendtsoeknad.common.AvdoedOMS
-import no.nav.etterlatte.libs.common.innsendtsoeknad.common.BarnOMS
+import no.nav.etterlatte.libs.common.innsendtsoeknad.common.Avdoed
+import no.nav.etterlatte.libs.common.innsendtsoeknad.common.Barn
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.BetingetOpplysning
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.EnumSvar
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.GjenlevendeOMS
@@ -25,8 +25,8 @@ data class Omstillingsstoenad(
     override val utbetalingsInformasjon: BetingetOpplysning<EnumSvar<BankkontoType>, UtbetalingsInformasjon>?,
 
     override val soeker: GjenlevendeOMS,
-    val avdoed: AvdoedOMS,
-    val barn: List<BarnOMS>,
+    val avdoed: Avdoed,
+    val barn: List<Barn>,
 ) : InnsendtSoeknad {
     override val versjon = "1"
     override val type: SoeknadType = SoeknadType.OMSTILLINGSSTOENAD

--- a/common/src/test/kotlin/innsendtsoeknad/common/InnsendtSoeknadTest.kt
+++ b/common/src/test/kotlin/innsendtsoeknad/common/InnsendtSoeknadTest.kt
@@ -10,6 +10,7 @@ import no.nav.etterlatte.libs.common.innsendtsoeknad.barnepensjon.Barnepensjon
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.InnsendtSoeknad
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadRequest
 import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
+import no.nav.etterlatte.libs.common.innsendtsoeknad.gjenlevendepensjon.Gjenlevendepensjon
 import no.nav.etterlatte.libs.common.innsendtsoeknad.omstillingsstoenad.Omstillingsstoenad
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -50,5 +51,21 @@ internal class InnsendtSoeknadTest {
 
         val soeknad = mapper.readValue<InnsendtSoeknad>(json)
         assertTrue(soeknad is Barnepensjon)
+    }
+
+    @Test
+    fun `Deserialisering av omstillingsstoenad`() {
+        val json = javaClass.getResource("/soeknad/omstillingsstoenad.json")!!.readText()
+
+        val soeknad = mapper.readValue<InnsendtSoeknad>(json)
+        assertTrue(soeknad is Omstillingsstoenad)
+    }
+
+    @Test
+    fun `Deserialisering av gjenlevendepensjon`() {
+        val json = javaClass.getResource("/soeknad/gjenlevendepensjon.json")!!.readText()
+
+        val soeknad = mapper.readValue<InnsendtSoeknad>(json)
+        assertTrue(soeknad is Gjenlevendepensjon)
     }
 }

--- a/common/src/test/resources/soeknad/gjenlevendepensjon.json
+++ b/common/src/test/resources/soeknad/gjenlevendepensjon.json
@@ -1,0 +1,563 @@
+{
+  "imageTag": "d79803f3acb657cf657ee46af1db293a665eb0d2",
+  "spraak": "nb",
+  "type": "GJENLEVENDEPENSJON",
+  "harSamtykket": {
+    "spoersmaal": "Jeg, TØFF DAL, bekrefter at jeg vil gi riktige og fullstendige opplysninger.",
+    "svar": true
+  },
+  "innsender": {
+    "type": "INNSENDER",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "TØFF"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "DAL"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer",
+      "svar": "14838099980"
+    }
+  },
+  "utbetalingsInformasjon": {
+    "spoersmaal": "Ønsker du å motta utbetalingen på norsk eller utenlandsk bankkonto?",
+    "svar": {
+      "verdi": "NORSK",
+      "innhold": "Norsk"
+    },
+    "opplysning": {
+      "kontonummer": {
+        "spoersmaal": "Oppgi norsk kontonummer for utbetaling",
+        "svar": {
+          "innhold": "1111.60.11554"
+        }
+      }
+    }
+  },
+  "soeker": {
+    "type": "GJENLEVENDE",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "TØFF"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "DAL"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer",
+      "svar": "14838099980"
+    },
+    "statsborgerskap": {
+      "spoersmaal": "Statsborgerskap",
+      "svar": "Norge"
+    },
+    "sivilstatus": {
+      "spoersmaal": "Sivilstatus",
+      "svar": "Enke eller enkemann"
+    },
+    "adresse": {
+      "spoersmaal": "Bostedsadresse",
+      "svar": "Nøsterudveien 48, 3060 Svelvik"
+    },
+    "kontaktinfo": {
+      "telefonnummer": {
+        "spoersmaal": "Telefonnummer",
+        "svar": {
+          "innhold": "+4799999999"
+        }
+      }
+    },
+    "oppholdUtland": {
+      "spoersmaal": "Har du oppholdt deg i Norge de siste 12 månedene?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      }
+    },
+    "nySivilstatus": {
+      "spoersmaal": "Sivilstanden din i dag",
+      "svar": {
+        "verdi": "ENSLIG",
+        "innhold": "Enslig"
+      }
+    },
+    "arbeidOgUtdanning": {
+      "dinSituasjon": {
+        "spoersmaal": "Hva er situasjonen din nå?",
+        "svar": [
+          {
+            "verdi": "ARBEIDSTAKER",
+            "innhold": "Jeg er arbeidstaker"
+          },
+          {
+            "verdi": "SELVSTENDIG",
+            "innhold": "Jeg er selvstendig næringsdrivende"
+          },
+          {
+            "verdi": "UNDER_UTDANNING",
+            "innhold": "Jeg tar utdanning"
+          },
+          {
+            "verdi": "ARBEIDSSOEKER",
+            "innhold": "Jeg er arbeidssøker"
+          },
+          {
+            "verdi": "INGEN",
+            "innhold": "Annet"
+          }
+        ]
+      },
+      "arbeidsforhold": {
+        "spoersmaal": "Om arbeidsgiver",
+        "svar": [
+          {
+            "arbeidsgiver": {
+              "spoersmaal": "Hva heter arbeidsgiver?",
+              "svar": {
+                "innhold": "Ledelse AS"
+              }
+            },
+            "ansettelsesforhold": {
+              "spoersmaal": "Type ansettelse",
+              "svar": {
+                "verdi": "SESONGARBEID",
+                "innhold": "Sesongansatt"
+              }
+            },
+            "stillingsprosent": {
+              "spoersmaal": "Hvor mye jobber du?",
+              "svar": {
+                "innhold": "100"
+              }
+            },
+            "endretInntekt": {
+              "spoersmaal": "Regner du med at inntekten din endrer seg de neste 12 månedene?",
+              "svar": {
+                "verdi": "JA",
+                "innhold": "Ja"
+              },
+              "opplysning": {
+                "spoersmaal": "Hva er grunnen til endringene?",
+                "svar": {
+                  "innhold": "Andre grunner"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "selvstendig": {
+        "spoersmaal": "Om næringen",
+        "svar": [
+          {
+            "firmanavn": {
+              "spoersmaal": "Om næringen",
+              "svar": {
+                "innhold": "Selvstendig firma ENK"
+              }
+            },
+            "orgnr": {
+              "spoersmaal": "Organisasjonsnummer",
+              "svar": {
+                "innhold": "999999999"
+              }
+            },
+            "endretInntekt": {
+              "spoersmaal": "Regner du med at inntekten din endrer seg de neste 12 månedene?",
+              "svar": {
+                "verdi": "JA",
+                "innhold": "Ja"
+              },
+              "opplysning": {
+                "spoersmaal": "Hva er grunnen til endringene?",
+                "svar": {
+                  "innhold": "Selger mye varer"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "utdanning": {
+        "spoersmaal": "dinSituasjon.utdanning.naavaerendeUtdanning.tittel",
+        "svar": {
+          "navn": {
+            "spoersmaal": "Navnet på utdanningen",
+            "svar": {
+              "innhold": "Heimdal vgs"
+            }
+          },
+          "startDato": {
+            "spoersmaal": "Fra dato",
+            "svar": {
+              "innhold": "2023-09-06"
+            }
+          },
+          "sluttDato": {
+            "spoersmaal": "Til dato",
+            "svar": {
+              "innhold": "2023-12-22"
+            }
+          }
+        }
+      },
+      "annet": {
+        "spoersmaal": "Velg det som beskriver situasjonen din fra nedtrekksmenyen.",
+        "svar": {
+          "innhold": "Etablerer bedrift",
+          "verdi": "ETABLERER_BEDRIFT"
+        }
+      }
+    },
+    "fullfoertUtdanning": {
+      "spoersmaal": "Hva er din høyeste fullførte utdanning?",
+      "svar": {
+        "verdi": "FAGBREV",
+        "innhold": "Fagbrev"
+      }
+    },
+    "andreYtelser": {
+      "kravOmAnnenStonad": {
+        "spoersmaal": "Har du søkt om andre ytelser som du ikke har fått svar på?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "spoersmaal": "Hva har du søkt om?",
+          "svar": {
+            "verdi": "OPPLAERINGSPENGER",
+            "innhold": "Opplæringspenger"
+          }
+        }
+      },
+      "annenPensjon": {
+        "spoersmaal": "Får du eller har du søkt om avtalefestet pensjon (AFP) eller annen pensjon fra andre enn NAV?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "spoersmaal": "Hvilken pensjonsordning?",
+          "svar": {
+            "innhold": "Skandia"
+          }
+        }
+      },
+      "pensjonUtland": {
+        "spoersmaal": "Mottar du pensjon fra et annet land enn Norge?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "pensjonsType": {
+            "spoersmaal": "Hva slags pensjon?",
+            "svar": {
+              "innhold": "Alder"
+            }
+          },
+          "land": {
+            "spoersmaal": "Fra hvilket land?",
+            "svar": {
+              "innhold": "Norge"
+            }
+          },
+          "bruttobeloepPrAar": {
+            "spoersmaal": "Årlig beløp før skatt i landets valuta",
+            "svar": {
+              "innhold": "6900"
+            }
+          }
+        }
+      }
+    },
+    "uregistrertEllerVenterBarn": {
+      "spoersmaal": "Venter du barn eller har du barn som enda ikke er registrert i folkeregisteret?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      }
+    },
+    "forholdTilAvdoede": {
+      "relasjon": {
+        "spoersmaal": "Relasjonen din til avdøde da dødsfallet skjedde",
+        "svar": {
+          "verdi": "SEPARERT",
+          "innhold": "Separert"
+        }
+      },
+      "datoForInngaattPartnerskap": {
+        "spoersmaal": "Vi giftet oss",
+        "svar": {
+          "innhold": "2023-12-01"
+        }
+      },
+      "fellesBarn": {
+        "spoersmaal": "Har eller hadde dere felles barn?",
+        "svar": {
+          "verdi": "NEI",
+          "innhold": "Nei"
+        }
+      },
+      "omsorgForBarn": {
+        "spoersmaal": "Hadde du omsorg for avdødes barn på dødstidspunktet?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        }
+      }
+    }
+  },
+  "avdoed": {
+    "type": "AVDOED",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "Avdød"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "Avdødsen"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer / d-nummer",
+      "svar": "23096800177"
+    },
+    "datoForDoedsfallet": {
+      "spoersmaal": "Når skjedde dødsfallet?",
+      "svar": {
+        "innhold": "2023-12-01"
+      }
+    },
+    "statsborgerskap": {
+      "spoersmaal": "Statsborgerskap",
+      "svar": {
+        "innhold": "Belgia"
+      }
+    },
+    "utenlandsopphold": {
+      "spoersmaal": "Har han eller hun bodd og/eller arbeidet i et annet land enn Norge etter fylte 16 år?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      },
+      "opplysning": [
+        {
+          "land": {
+            "spoersmaal": "Land",
+            "svar": {
+              "innhold": "Argentina"
+            }
+          },
+          "fraDato": {
+            "spoersmaal": "Fra dato (valgfri)",
+            "svar": {
+              "innhold": "2023-10-04"
+            }
+          },
+          "tilDato": {
+            "spoersmaal": "Til dato (valgfri)",
+            "svar": {
+              "innhold": "2023-11-16"
+            }
+          },
+          "oppholdsType": {
+            "spoersmaal": "Bodd og/eller arbeidet?",
+            "svar": [
+              {
+                "verdi": "BODD",
+                "innhold": "Bodd"
+              }
+            ]
+          },
+          "medlemFolketrygd": {
+            "spoersmaal": "Var han eller hun medlem av folketrygden under oppholdet?",
+            "svar": {
+              "verdi": "NEI",
+              "innhold": "Nei"
+            }
+          },
+          "pensjonsutbetaling": {
+            "spoersmaal": "Oppgi eventuell pensjon han eller hun mottok fra dette landet (valgfri)",
+            "svar": {
+              "innhold": "150 svenske kroner"
+            }
+          }
+        }
+      ]
+    },
+    "naeringsInntekt": {
+      "spoersmaal": "Var han eller hun selvstendig næringsdrivende?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      },
+      "opplysning": {
+        "naeringsinntektPrAarFoerDoedsfall": {
+          "spoersmaal": "Oppgi næringsinntekt fra kalenderåret før dødsfallet (valgfri)",
+          "svar": {
+            "innhold": "199"
+          }
+        },
+        "naeringsinntektVedDoedsfall": {
+          "spoersmaal": "Hadde han eller hun næringsinntekt når dødsfallet skjedde?",
+          "svar": {
+            "verdi": "JA",
+            "innhold": "Ja"
+          }
+        }
+      }
+    },
+    "militaertjeneste": {
+      "spoersmaal": "Har han eller hun gjennomført militær eller sivil førstegangstjeneste for Norge som varte minst 30 dager?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      },
+      "opplysning": {
+        "spoersmaal": "Hvilke(-t) år? (valgfri)",
+        "svar": {
+          "innhold": "1969"
+        }
+      }
+    },
+    "doedsaarsakSkyldesYrkesskadeEllerYrkessykdom": {
+      "spoersmaal": "Skyldes dødsfallet yrkesskade eller yrkessykdom?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      }
+    }
+  },
+  "barn": [
+    {
+      "type": "BARN",
+      "fornavn": {
+        "spoersmaal": "Fornavn",
+        "svar": "Testmini"
+      },
+      "etternavn": {
+        "spoersmaal": "Etternavn",
+        "svar": "Minion"
+      },
+      "foedselsnummer": {
+        "spoersmaal": "Barnets fødselsnummer / d-nummer",
+        "svar": "05111850870"
+      },
+      "statsborgerskap": {
+        "spoersmaal": "Statsborgerskap",
+        "svar": "Andorra"
+      },
+      "utenlandsAdresse": {
+        "spoersmaal": "Bor barnet i et annet land enn Norge?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "land": {
+            "spoersmaal": "Land",
+            "svar": {
+              "innhold": "Australia"
+            }
+          },
+          "adresse": {
+            "spoersmaal": "Adresse i utlandet",
+            "svar": {
+              "innhold": "Utlandet"
+            }
+          }
+        }
+      },
+      "foreldre": [
+        {
+          "type": "FORELDER",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "TØFF"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "DAL"
+          },
+          "foedselsnummer": {
+            "spoersmaal": "Fødselsnummer",
+            "svar": "14838099980"
+          }
+        },
+        {
+          "type": "FORELDER",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "Avdød"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "Avdødsen"
+          },
+          "foedselsnummer": {
+            "spoersmaal": "Fødselsnummer",
+            "svar": "23096800177"
+          }
+        }
+      ],
+      "verge": {
+        "spoersmaal": "Er det oppnevnt en verge for barnet?",
+        "svar": {
+          "verdi": "JA",
+          "innhold": "Ja"
+        },
+        "opplysning": {
+          "type": "VERGE",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "Verg"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "Erge"
+          },
+          "foedselsnummer": {
+            "spoersmaal": "Fødselsnummer",
+            "svar": "25027702638"
+          }
+        }
+      }
+    }
+  ],
+  "andreStoenader": [
+    {
+      "spoersmaal": "Informasjon om stønad til skolepenger",
+      "svar": {
+        "innhold": "Jeg har utgifter til skolepenger",
+        "verdi": "SKOLEPENGER"
+      }
+    },
+    {
+      "spoersmaal": "Informasjon om tilleggsstønad til skoleutgifter",
+      "svar": {
+        "innhold": "Jeg har utgifter til utdanning",
+        "verdi": "TILLEGGSSTOENAD_UTDANNING"
+      }
+    },
+    {
+      "spoersmaal": "Informasjon om stønad til barnetilsyn",
+      "svar": {
+        "innhold": "Jeg har utgifter til barnetilsyn",
+        "verdi": "BARNETILSYN"
+      }
+    },
+    {
+      "spoersmaal": "Informasjon om tilleggsstønad til pass av barn",
+      "svar": {
+        "innhold": "Jeg har utgifter til pass av barn",
+        "verdi": "TILLEGGSSTOENAD_BARNEPASS"
+      }
+    }
+  ],
+  "mottattDato": "2023-11-30T18:05:49.337092713",
+  "template": "gjenlevendepensjon_v2"
+}

--- a/common/src/test/resources/soeknad/omstillingsstoenad.json
+++ b/common/src/test/resources/soeknad/omstillingsstoenad.json
@@ -1,0 +1,320 @@
+{
+  "imageTag": "d79803f3acb657cf657ee46af1db293a665eb0d2",
+  "spraak": "nb",
+  "type": "OMSTILLINGSSTOENAD",
+  "harSamtykket": {
+    "spoersmaal": "Jeg vil svare så godt jeg kan på spørsmålene i søknaden.",
+    "svar": true
+  },
+  "innsender": {
+    "type": "INNSENDER",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "TRADISJONSBUNDEN"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "KØYESENG"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer",
+      "svar": "13848599411"
+    }
+  },
+  "utbetalingsInformasjon": {
+    "spoersmaal": "Ønsker du å motta utbetalingen på norsk eller utenlandsk bankkonto?",
+    "svar": {
+      "verdi": "NORSK",
+      "innhold": "Norsk"
+    },
+    "opplysning": {
+      "kontonummer": {
+        "spoersmaal": "Oppgi norsk kontonummer for utbetaling",
+        "svar": {
+          "innhold": "1411.35.13515"
+        }
+      }
+    }
+  },
+  "soeker": {
+    "type": "GJENLEVENDE_OMS",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "TRADISJONSBUNDEN"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "KØYESENG"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer",
+      "svar": "13848599411"
+    },
+    "statsborgerskap": {
+      "spoersmaal": "Statsborgerskap",
+      "svar": "Norge"
+    },
+    "sivilstatus": {
+      "spoersmaal": "Sivilstatus",
+      "svar": "Gift"
+    },
+    "adresse": {
+      "spoersmaal": "Bostedsadresse",
+      "svar": "Tonnesveien 275, 8750 Tonnes"
+    },
+    "kontaktinfo": {
+      "telefonnummer": {
+        "spoersmaal": "Telefonnummer",
+        "svar": {
+          "innhold": "+4799999999"
+        }
+      }
+    },
+    "oppholdUtland": {
+      "spoersmaal": "Er du bosatt i Norge?",
+      "svar": {
+        "verdi": "JA",
+        "innhold": "Ja"
+      },
+      "opplysning": {
+        "oppholderSegIUtlandet": {
+          "spoersmaal": "Har du bodd eller oppholdt deg i utlandet de siste 12 månedene?",
+          "svar": {
+            "verdi": "NEI",
+            "innhold": "Nei"
+          }
+        }
+      }
+    },
+    "nySivilstatus": {
+      "spoersmaal": "Sivilstanden din i dag",
+      "svar": {
+        "verdi": "ENSLIG",
+        "innhold": "Enslig"
+      }
+    },
+    "arbeidOgUtdanning": {
+      "dinSituasjon": {
+        "spoersmaal": "Hva er situasjonen din nå?",
+        "svar": [
+          {
+            "verdi": "ARBEIDSSOEKER",
+            "innhold": "Jeg er arbeidssøker"
+          }
+        ]
+      },
+      "arbeidssoeker": {
+        "spoersmaal": "Om arbeidssøkingen",
+        "svar": {
+          "registrertArbeidssoeker": {
+            "spoersmaal": "Er du registrert som arbeidssøker hos NAV?",
+            "svar": {
+              "verdi": "NEI",
+              "innhold": "Nei"
+            }
+          }
+        }
+      }
+    },
+    "fullfoertUtdanning": {
+      "spoersmaal": "Hva er din høyeste fullførte utdanning?",
+      "svar": [
+        {
+          "verdi": "INGEN",
+          "innhold": "Ingen utdanning"
+        }
+      ]
+    },
+    "inntektOgPensjon": {
+      "annenInntekt": {
+        "annenInntektEllerUtbetaling": {
+          "spoersmaal": "Hvilke andre inntekter eller utbetalinger har du?",
+          "svar": [
+            {
+              "verdi": "ANNEN",
+              "innhold": "Andre inntekter eller ytelser"
+            }
+          ]
+        },
+        "beloep": {
+          "spoersmaal": "Oppgi brutto inntekt eller ytelser",
+          "svar": {
+            "innhold": "150000"
+          }
+        }
+      },
+      "ytelserNAV": {
+        "soektOmYtelse": {
+          "spoersmaal": "Har du søkt om ytelser fra NAV som du ikke har fått svar på?",
+          "svar": {
+            "verdi": "NEI",
+            "innhold": "Nei"
+          }
+        }
+      },
+      "ytelserAndre": {
+        "soektOmYtelse": {
+          "spoersmaal": "Har du søkt om ytelser fra andre enn NAV som du ikke har fått svar på?",
+          "svar": {
+            "verdi": "NEI",
+            "innhold": "Nei"
+          }
+        }
+      }
+    },
+    "uregistrertEllerVenterBarn": {
+      "spoersmaal": "Venter du barn eller har du barn som ikke er registrert i folkeregisteret?",
+      "svar": {
+        "verdi": "NEI",
+        "innhold": "Nei"
+      }
+    },
+    "forholdTilAvdoede": {
+      "relasjon": {
+        "spoersmaal": "Relasjonen din til avdøde da dødsfallet skjedde",
+        "svar": {
+          "verdi": "GIFT",
+          "innhold": "Gift eller registrert partner"
+        }
+      },
+      "datoForInngaattPartnerskap": {
+        "spoersmaal": "Vi giftet oss",
+        "svar": {
+          "innhold": "2001-01-01"
+        }
+      },
+      "fellesBarn": {
+        "spoersmaal": "Har eller har dere hatt felles barn?",
+        "svar": {
+          "verdi": "NEI",
+          "innhold": "Nei"
+        }
+      }
+    },
+    "omsorgForBarn": {
+      "spoersmaal": "Har du minst 50 prosent omsorg for barn under 18 år på dødsfallstidspunktet?",
+      "svar": {
+        "verdi": "NEI",
+        "innhold": "Nei"
+      }
+    }
+  },
+  "avdoed": {
+    "type": "AVDOED",
+    "fornavn": {
+      "spoersmaal": "Fornavn",
+      "svar": "TREG"
+    },
+    "etternavn": {
+      "spoersmaal": "Etternavn",
+      "svar": "BILLE"
+    },
+    "foedselsnummer": {
+      "spoersmaal": "Fødselsnummer / d-nummer",
+      "svar": "03428317423"
+    },
+    "datoForDoedsfallet": {
+      "spoersmaal": "Når skjedde dødsfallet?",
+      "svar": {
+        "innhold": "2023-11-15"
+      }
+    },
+    "statsborgerskap": {
+      "spoersmaal": "Statsborgerskap",
+      "svar": {
+        "innhold": "Norge"
+      }
+    },
+    "utenlandsopphold": {
+      "spoersmaal": "Har han eller hun bodd og/eller arbeidet i et annet land enn Norge etter fylte 16 år?",
+      "svar": {
+        "verdi": "NEI",
+        "innhold": "Nei"
+      }
+    },
+    "naeringsInntekt": {
+      "spoersmaal": "Var han eller hun selvstendig næringsdrivende?",
+      "svar": {
+        "verdi": "NEI",
+        "innhold": "Nei"
+      }
+    },
+    "doedsaarsakSkyldesYrkesskadeEllerYrkessykdom": {
+      "spoersmaal": "Skyldes dødsfallet yrkesskade eller yrkessykdom?",
+      "svar": {
+        "verdi": "NEI",
+        "innhold": "Nei"
+      }
+    }
+  },
+  "barn": [
+    {
+      "type": "BARN",
+      "fornavn": {
+        "spoersmaal": "Fornavn",
+        "svar": "Blaut "
+      },
+      "etternavn": {
+        "spoersmaal": "Etternavn",
+        "svar": "Sandkasse"
+      },
+      "foedselsnummer": {
+        "spoersmaal": "Barnets fødselsnummer / d-nummer",
+        "svar": "19021370870"
+      },
+      "statsborgerskap": {
+        "spoersmaal": "Statsborgerskap",
+        "svar": "Norge"
+      },
+      "utenlandsAdresse": {
+        "spoersmaal": "Bor barnet i et annet land enn Norge?",
+        "svar": {
+          "verdi": "NEI",
+          "innhold": "Nei"
+        }
+      },
+      "foreldre": [
+        {
+          "type": "FORELDER",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "TRADISJONSBUNDEN"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "KØYESENG"
+          },
+          "foedselsnummer": {
+            "spoersmaal": "Fødselsnummer",
+            "svar": "13848599411"
+          }
+        },
+        {
+          "type": "FORELDER",
+          "fornavn": {
+            "spoersmaal": "Fornavn",
+            "svar": "TREG"
+          },
+          "etternavn": {
+            "spoersmaal": "Etternavn",
+            "svar": "BILLE"
+          },
+          "foedselsnummer": {
+            "spoersmaal": "Fødselsnummer",
+            "svar": "03428317423"
+          }
+        }
+      ],
+      "verge": {
+        "spoersmaal": "Er det oppnevnt en verge for barnet?",
+        "svar": {
+          "verdi": "NEI",
+          "innhold": "Nei"
+        }
+      }
+    }
+  ],
+  "andreStoenader": [],
+  "mottattDato": "2023-11-30T18:05:49.337092713",
+  "template": "omstillingsstoenad_v2"
+}


### PR DESCRIPTION
Midlertidig slå sammen Avdød/Barn GP og OMS. Blir noen unødvendige felter, men vil ikke ha noe å si ettersom de uansett bare vil være tomme og utgjør ingen forskjell på PDF-en. 

Gjenlevende OMS og GP er så ulike at de må ha hvert sitt objekt og PersonType. 

Må gjøres en grundig opprydding når gjenlevendepensjon utgår. 