### PR TITLE
EY-3256: La inntekt etter doedsfall være optional

### DIFF
--- a/common/src/main/kotlin/no/nav/etterlatte/libs/common/innsendtsoeknad/common/Opplysninger.kt
+++ b/common/src/main/kotlin/no/nav/etterlatte/libs/common/innsendtsoeknad/common/Opplysninger.kt
@@ -281,7 +281,7 @@ data class InntektSamlet(
 )
 data class TilOgEtterDoedsfall(
     val tilDoedsfall: Opplysning<FritekstSvar>,
-    val etterDoedsfall: Opplysning<FritekstSvar>
+    val etterDoedsfall: Opplysning<FritekstSvar>?
 )
 
 data class EndringAvInntekt(


### PR DESCRIPTION
Tilhørende PR: https://github.com/navikt/pensjon-etterlatte/pull/970