### PR TITLE
Ta med behandlingsnummer i pdl request adressebeskyttelse

### DIFF
--- a/common/src/main/kotlin/no/nav/etterlatte/libs/common/innsendtsoeknad/common/SoeknadType.kt
+++ b/common/src/main/kotlin/no/nav/etterlatte/libs/common/innsendtsoeknad/common/SoeknadType.kt
@@ -5,3 +5,18 @@ enum class SoeknadType(val behandlingstema: String) {
     BARNEPENSJON("ab0255"),
     OMSTILLINGSSTOENAD("oms_behandlingstema_placeholder")
 }
+
+
+fun finnBehandlingsnummerFromSaktype(saktype: SoeknadType): Behandlingsnummer {
+    return when (saktype) {
+        SoeknadType.GJENLEVENDEPENSJON -> Behandlingsnummer.GJENLEVENDEPENSJON
+        SoeknadType.BARNEPENSJON -> Behandlingsnummer.BARNEPENSJON
+        SoeknadType.OMSTILLINGSSTOENAD -> Behandlingsnummer.OMSTILLINGSSTOENAD
+    }
+}
+
+enum class Behandlingsnummer(val behandlingsnummer: String) {
+    BARNEPENSJON("B359"),
+    OMSTILLINGSSTOENAD("B373"),
+    GJENLEVENDEPENSJON("B222"),
+}

--- a/common/src/main/kotlin/no/nav/etterlatte/libs/common/pdl/AdressebeskyttelseKlient.kt
+++ b/common/src/main/kotlin/no/nav/etterlatte/libs/common/pdl/AdressebeskyttelseKlient.kt
@@ -12,7 +12,7 @@ import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import org.slf4j.LoggerFactory
 
 interface Pdl {
-    suspend fun finnAdressebeskyttelseForFnr(fnrListe: List<Foedselsnummer>): AdressebeskyttelseResponse
+    suspend fun finnAdressebeskyttelseForFnr(fnrListe: List<Foedselsnummer>, behandlingsnummer: String): AdressebeskyttelseResponse
 }
 
 class AdressebeskyttelseKlient(private val client: HttpClient, private val apiUrl: String) : Pdl {
@@ -26,13 +26,16 @@ class AdressebeskyttelseKlient(private val client: HttpClient, private val apiUr
      *
      * @return [AdressebeskyttelseResponse]: Responsobjekt fra PDL.
      */
-    override suspend fun finnAdressebeskyttelseForFnr(fnrListe: List<Foedselsnummer>): AdressebeskyttelseResponse {
+    override suspend fun finnAdressebeskyttelseForFnr(fnrListe: List<Foedselsnummer>, behandlingsnummer: String):
+            AdressebeskyttelseResponse {
+
         val query = hentQuery()
 
         val request = GraphqlRequest(query, Variables(identer = fnrListe.map { it.value }))
 
         val response = client.post(apiUrl) {
-            header("Tema", "PEN")
+            header(HEADER_TEMA, HEADER_TEMA_VALUE)
+            header(HEADER_BEHANDLINGSNUMMER, behandlingsnummer)
             accept(ContentType.Application.Json)
             contentType(ContentType.Application.Json)
             setBody(request)
@@ -44,6 +47,12 @@ class AdressebeskyttelseKlient(private val client: HttpClient, private val apiUr
         }
 
         return response
+    }
+
+    companion object {
+        const val HEADER_BEHANDLINGSNUMMER = "behandlingsnummer"
+        const val HEADER_TEMA = "Tema"
+        const val HEADER_TEMA_VALUE = "PEN"
     }
 
     private fun hentQuery(): String = javaClass.getResource("/pdl/hentAdressebeskyttelse.graphql")!!

--- a/common/src/main/kotlin/no/nav/etterlatte/libs/common/pdl/AdressebeskyttelseKlient.kt
+++ b/common/src/main/kotlin/no/nav/etterlatte/libs/common/pdl/AdressebeskyttelseKlient.kt
@@ -8,11 +8,13 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
+import no.nav.etterlatte.libs.common.innsendtsoeknad.common.finnBehandlingsnummerFromSaktype
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
 import org.slf4j.LoggerFactory
 
 interface Pdl {
-    suspend fun finnAdressebeskyttelseForFnr(fnrListe: List<Foedselsnummer>, behandlingsnummer: String): AdressebeskyttelseResponse
+    suspend fun finnAdressebeskyttelseForFnr(fnrListe: List<Foedselsnummer>, saktype: SoeknadType): AdressebeskyttelseResponse
 }
 
 class AdressebeskyttelseKlient(private val client: HttpClient, private val apiUrl: String) : Pdl {
@@ -26,12 +28,14 @@ class AdressebeskyttelseKlient(private val client: HttpClient, private val apiUr
      *
      * @return [AdressebeskyttelseResponse]: Responsobjekt fra PDL.
      */
-    override suspend fun finnAdressebeskyttelseForFnr(fnrListe: List<Foedselsnummer>, behandlingsnummer: String):
+    override suspend fun finnAdressebeskyttelseForFnr(fnrListe: List<Foedselsnummer>, saktype: SoeknadType):
             AdressebeskyttelseResponse {
 
         val query = hentQuery()
 
         val request = GraphqlRequest(query, Variables(identer = fnrListe.map { it.value }))
+
+        val behandlingsnummer = finnBehandlingsnummerFromSaktype(saktype)
 
         val response = client.post(apiUrl) {
             header(HEADER_TEMA, HEADER_TEMA_VALUE)

--- a/common/src/test/kotlin/pdl/AdressebeskyttelseKlientTest.kt
+++ b/common/src/test/kotlin/pdl/AdressebeskyttelseKlientTest.kt
@@ -11,6 +11,7 @@ import io.ktor.serialization.jackson.jackson
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.innsendtsoeknad.common.SoeknadType
 import no.nav.etterlatte.libs.common.pdl.Gradering
 import no.nav.etterlatte.libs.common.pdl.AdressebeskyttelseKlient
 import no.nav.etterlatte.libs.common.person.Foedselsnummer
@@ -43,7 +44,7 @@ internal class AdressebeskyttelseKlientTest {
         }
 
         runBlocking {
-            AdressebeskyttelseKlient(httpClient, "https://pdl.no/").finnAdressebeskyttelseForFnr(listOf(fnr)).also {
+            AdressebeskyttelseKlient(httpClient, "https://pdl.no/").finnAdressebeskyttelseForFnr(listOf(fnr), SoeknadType.BARNEPENSJON).also {
                 assertEquals(
                     Gradering.FORTROLIG,
                     it.data?.hentPersonBolk?.get(0)?.person?.adressebeskyttelse?.get(0)?.gradering


### PR DESCRIPTION
Trenger dette for å kunne sende inn sakstype fra selvbetjening-api og sjekk-adressebeskyttelse appene som bruker denne.