### PR TITLE
fix: Send med behandlingsnummer, ikke navnet på stønaden

### DIFF
--- a/common/src/main/kotlin/no/nav/etterlatte/libs/common/pdl/AdressebeskyttelseKlient.kt
+++ b/common/src/main/kotlin/no/nav/etterlatte/libs/common/pdl/AdressebeskyttelseKlient.kt
@@ -35,7 +35,7 @@ class AdressebeskyttelseKlient(private val client: HttpClient, private val apiUr
 
         val request = GraphqlRequest(query, Variables(identer = fnrListe.map { it.value }))
 
-        val behandlingsnummer = finnBehandlingsnummerFromSaktype(saktype)
+        val behandlingsnummer = finnBehandlingsnummerFromSaktype(saktype).behandlingsnummer
 
         val response = client.post(apiUrl) {
             header(HEADER_TEMA, HEADER_TEMA_VALUE)


### PR DESCRIPTION
Oppdaget at vi sendte `OMSTILLINGSSTOENAD` og `BARNEPENSJON` som behandlingsnummer.